### PR TITLE
Add initial Express API server

### DIFF
--- a/apps/api-server/.gitignore
+++ b/apps/api-server/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+dist

--- a/apps/api-server/nodemon.json
+++ b/apps/api-server/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["src"],
+  "ext": "ts",
+  "exec": "ts-node src/server.ts"
+}

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "api-server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node dist/index.js",
+    "dev": "nodemon",
+    "build": "tsc",
+    "prisma": "prisma"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@prisma/client": "^5.0.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
+    "helmet": "^7.0.0",
+    "prisma": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.0.0",
+    "nodemon": "^3.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/api-server/prisma/schema.prisma
+++ b/apps/api-server/prisma/schema.prisma
@@ -1,0 +1,8 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}

--- a/apps/api-server/src/index.ts
+++ b/apps/api-server/src/index.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import { router as routes } from './routes';
+import { errorHandler } from './middleware/errorHandler';
+
+const app = express();
+
+app.use(express.json());
+app.use(cors());
+app.use(helmet());
+app.use(
+  rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 100,
+  })
+);
+
+app.use('/api', routes);
+
+app.use(errorHandler);
+
+export default app;

--- a/apps/api-server/src/middleware/errorHandler.ts
+++ b/apps/api-server/src/middleware/errorHandler.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  console.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+}

--- a/apps/api-server/src/prisma/client.ts
+++ b/apps/api-server/src/prisma/client.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/apps/api-server/src/routes/auth/index.ts
+++ b/apps/api-server/src/routes/auth/index.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import otp from './otp';
+
+const router = Router();
+
+router.use('/otp', otp);
+
+export default router;

--- a/apps/api-server/src/routes/auth/otp.ts
+++ b/apps/api-server/src/routes/auth/otp.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/', (_req, res) => {
+  res.json({ message: 'OTP endpoint' });
+});
+
+export default router;

--- a/apps/api-server/src/routes/health.ts
+++ b/apps/api-server/src/routes/health.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+export default router;

--- a/apps/api-server/src/routes/index.ts
+++ b/apps/api-server/src/routes/index.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import health from './health';
+import auth from './auth';
+
+export const router = Router();
+
+router.use('/health', health);
+router.use('/auth', auth);

--- a/apps/api-server/src/server.ts
+++ b/apps/api-server/src/server.ts
@@ -1,0 +1,7 @@
+import app from './index';
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/apps/api-server/tsconfig.json
+++ b/apps/api-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold apps/api-server with Express and TypeScript
- add routing architecture with health and auth/otp routes
- include nodemon, CORS, Helmet, and rate limiting middleware
- implement global error handler and Prisma client setup

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express' because deps not installed)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e9d90710883259d6b2af5762279a2