### PR TITLE
Configure Postgres schema

### DIFF
--- a/apps/api-server/.env.example
+++ b/apps/api-server/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for local development
+DATABASE_URL="postgresql://postgres:password@localhost:5432/mosque"

--- a/apps/api-server/prisma/migrations/0001_init/README.md
+++ b/apps/api-server/prisma/migrations/0001_init/README.md
@@ -1,0 +1,1 @@
+Initial migration creating Admin and Mosque tables.

--- a/apps/api-server/prisma/migrations/0001_init/migration.sql
+++ b/apps/api-server/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "Admin" (
+    "id" SERIAL NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Admin_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Mosque" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Mosque_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Admin_email_key" ON "Admin" ("email");

--- a/apps/api-server/prisma/schema.prisma
+++ b/apps/api-server/prisma/schema.prisma
@@ -1,8 +1,22 @@
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 
 generator client {
   provider = "prisma-client-js"
+}
+
+model Admin {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+}
+
+model Mosque {
+  id        Int      @id @default(autoincrement())
+  name      String
+  address   String
+  createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- switch Prisma datasource to PostgreSQL
- add Admin and Mosque models
- provide initial migration
- document example env vars

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx prisma generate` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685e9ee4de908325b530069be38e315f